### PR TITLE
Wip/update jdnconvertiblecalendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/platform-browser-dynamic": "^7.2.7",
     "@angular/router": "^7.2.7",
     "core-js": "^2.5.4",
-    "jdnconvertiblecalendar": "0.0.2",
+    "jdnconvertiblecalendar": "0.0.3",
     "rxjs": "^6.0.0",
     "zone.js": "^0.8.26"
   },

--- a/projects/jdnconvertible-calendar-date-adapter/README.md
+++ b/projects/jdnconvertible-calendar-date-adapter/README.md
@@ -6,9 +6,9 @@
 
 ## Introduction
 
-`JDNConvertibleCalendarDateAdapter` provides an implementation of the Angular Material 2 `DateAdapter` 
+`JDNConvertibleCalendarDateAdapter` provides an implementation of the Angular Material `DateAdapter` 
 (<https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings>) for `JDNConvertibleCalendar` (<https://www.npmjs.com/package/jdnconvertiblecalendar>), 
-so that the Angular Material 2 DatePicker UI can be used with different calendar formats.
+so that the Angular Material DatePicker UI can be used with different calendar formats.
 
 ## NPM Package
 
@@ -20,3 +20,7 @@ Add `jdnconvertiblecalendardateadapter` and `jdnconvertiblecalendar` to the depe
 Add `MatJDNConvertibleCalendarDateAdapterModule` to your application's module configuration. See <https://github.com/dhlab-basel/JDNConvertibleCalendarDateAdapter/blob/develop/src/app/app.module.ts> as an example. 
 
 See also <https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings> for instructions how to integrate it with Angular Material 2.
+
+## Angular Version
+
+This module works with Angular 7 and Angular Material 7 (see `projects/jdnconvertible-calendar-date-adapter/package.json`). 

--- a/projects/jdnconvertible-calendar-date-adapter/package.json
+++ b/projects/jdnconvertible-calendar-date-adapter/package.json
@@ -24,6 +24,6 @@
     "@angular/animations": "^7.2.7",
     "@angular/cdk": "^7.3.3",
     "@angular/material": "^7.3.3",
-    "jdnconvertiblecalendar": "0.0.2"
+    "jdnconvertiblecalendar": "0.0.3"
   }
 }

--- a/projects/jdnconvertible-calendar-date-adapter/package.json
+++ b/projects/jdnconvertible-calendar-date-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdnconvertiblecalendardateadapter",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Implementation of Angular Material 2 DateAdapter for JDNConvertibleCalendar",
   "keywords": [
     "Angular Material Datepicker",

--- a/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.spec.ts
+++ b/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.spec.ts
@@ -316,8 +316,7 @@ describe('JDNConvertibleCalendarDateAdapter', () => {
 
     const expectedCalDate = new CalendarDate(year, month + 1, day);
 
-    const jdn = JDNConvertibleConversionModule.gregorianToJDN(expectedCalDate);
-    const todayCalDate: GregorianCalendarDate = new GregorianCalendarDate(new JDNPeriod(jdn, jdn));
+    const todayCalDate: GregorianCalendarDate = new GregorianCalendarDate(new CalendarPeriod(expectedCalDate, expectedCalDate));
 
     expect(adapter.activeCalendarFormat).toEqual('Gregorian'); // Gregorian is the standard if no conversions have been done
     expect(today).toEqual(todayCalDate);

--- a/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.spec.ts
+++ b/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.spec.ts
@@ -8,6 +8,8 @@ import {
 import {JDNConvertibleCalendarDateAdapter, JDNConvertibleCalendarDateAdapterModule} from '../public_api';
 import {async, inject, TestBed} from '@angular/core/testing';
 import {DateAdapter} from '@angular/material';
+import {JDNConvertibleCalendarModule} from "jdnconvertiblecalendar/dist/src/JDNConvertibleCalendar";
+import CalendarPeriod = JDNConvertibleCalendarModule.CalendarPeriod;
 
 describe('JDNConvertibleCalendarDateAdapter', () => {
   let adapter: JDNConvertibleCalendarDateAdapter;
@@ -38,30 +40,30 @@ describe('JDNConvertibleCalendarDateAdapter', () => {
 
   it('should get year', () => {
     // January 1 2017
-    const jdn = 2457755;
+    const calDate = new CalendarDate(2017, 1, 1);
 
-    expect(adapter.getYear(new GregorianCalendarDate(new JDNPeriod(jdn, jdn)))).toBe(2017);
+    expect(adapter.getYear(new GregorianCalendarDate(new CalendarPeriod(calDate, calDate)))).toBe(2017);
   });
 
   it('should get month', () => {
     // January 1 2017
-    const jdn = 2457755;
+    const calDate = new CalendarDate(2017, 1, 1);
 
-    expect(adapter.getMonth(new GregorianCalendarDate(new JDNPeriod(jdn, jdn)))).toBe(0);
+    expect(adapter.getMonth(new GregorianCalendarDate(new CalendarPeriod(calDate, calDate)))).toBe(0);
   });
 
   it('should get date', () => {
     // January 1 2017
-    const jdn = 2457755;
+    const calDate = new CalendarDate(2017, 1, 1);
 
-    expect(adapter.getDate(new GregorianCalendarDate(new JDNPeriod(jdn, jdn)))).toBe(1);
+    expect(adapter.getDate(new GregorianCalendarDate(new CalendarPeriod(calDate, calDate)))).toBe(1);
   });
 
   it('should get day of week', () => {
     // January 1 2017
-    const jdn = 2457755;
+    const calDate = new CalendarDate(2017, 1, 1);
 
-    expect(adapter.getDayOfWeek(new GregorianCalendarDate(new JDNPeriod(jdn, jdn)))).toBe(0);
+    expect(adapter.getDayOfWeek(new GregorianCalendarDate(new CalendarPeriod(calDate, calDate)))).toBe(0);
   });
 
   it('should get long month names', () => {
@@ -81,9 +83,9 @@ describe('JDNConvertibleCalendarDateAdapter', () => {
 
   it('should get year name', () => {
     // January 1 2017
-    const jdn = 2457755;
+    const calDate = new CalendarDate(2017, 1, 1);
 
-    expect(adapter.getYearName(new GregorianCalendarDate(new JDNPeriod(jdn, jdn)))).toBe('2017');
+    expect(adapter.getYearName(new GregorianCalendarDate(new CalendarPeriod(calDate, calDate)))).toBe('2017');
   });
 
   it('should get first day of week', () => {
@@ -96,9 +98,9 @@ describe('JDNConvertibleCalendarDateAdapter', () => {
 
   it('should parse string according to given format', () => {
     // January 2 2017
-    const jdn = 2457756;
+    const calDate = new CalendarDate(2017, 1, 2);
 
-    expect(adapter.parse('02-01-2017', 'DD-MM-YYYY')).toEqual(new GregorianCalendarDate(new JDNPeriod(jdn, jdn)));
+    expect(adapter.parse('02-01-2017', 'DD-MM-YYYY')).toEqual(new GregorianCalendarDate(new CalendarPeriod(calDate, calDate)));
 
   });
 

--- a/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.ts
+++ b/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.ts
@@ -199,16 +199,12 @@ export class JDNConvertibleCalendarDateAdapter extends DateAdapter<JDNConvertibl
     // month param is 0 indexed, but we use 1 based index for months
     const calDate = new CalendarDate(year, month + 1, date);
 
-    let jdn;
-
     switch (calendar) {
       case 'Gregorian':
-        jdn = JDNConvertibleConversionModule.gregorianToJDN(calDate);
-        return new GregorianCalendarDate(new JDNPeriod(jdn, jdn));
+        return new GregorianCalendarDate(new CalendarPeriod(calDate, calDate));
 
       case 'Julian':
-        jdn = JDNConvertibleConversionModule.julianToJDN(calDate);
-        return new JulianCalendarDate(new JDNPeriod(jdn, jdn));
+        return new JulianCalendarDate(new CalendarPeriod(calDate, calDate));
     }
   }
 

--- a/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.ts
+++ b/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.ts
@@ -22,6 +22,7 @@ import {Injectable} from '@angular/core';
 import {DateAdapter} from '@angular/material';
 import {
   CalendarDate,
+  CalendarPeriod,
   GregorianCalendarDate,
   JDNConvertibleCalendar,
   JDNConvertibleConversionModule,
@@ -232,10 +233,12 @@ export class JDNConvertibleCalendarDateAdapter extends DateAdapter<JDNConvertibl
     const day = today.getDate();
 
     // create a Gregorian calendar date from the native JS object
-    const dateGregorian = this.createCalendarDate(year, month, day, 'Gregorian');
+    const calDate = new CalendarDate(year, month + 1, day);
+
+    const dateGregorian = new GregorianCalendarDate(new CalendarPeriod(calDate, calDate));
 
     // convert the date to the active calendar format
-    const date = this.convertCalendarFormat(dateGregorian, this._activeCalendarFormat);
+    const date: JDNConvertibleCalendar = this.convertCalendarFormat(dateGregorian, this._activeCalendarFormat);
 
     return date;
 

--- a/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.ts
+++ b/projects/jdnconvertible-calendar-date-adapter/src/lib/jdnconvertible-calendar-date-adapter.ts
@@ -229,6 +229,7 @@ export class JDNConvertibleCalendarDateAdapter extends DateAdapter<JDNConvertibl
     const day = today.getDate();
 
     // create a Gregorian calendar date from the native JS object
+    // month used a 1 based index
     const calDate = new CalendarDate(year, month + 1, day);
 
     const dateGregorian = new GregorianCalendarDate(new CalendarPeriod(calDate, calDate));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4051,10 +4051,10 @@ jasminewd2@^2.1.0:
   resolved "https://registry.yarnpkg.com/jasminewd2/-/jasminewd2-2.2.0.tgz#e37cf0b17f199cce23bea71b2039395246b4ec4e"
   integrity sha1-43zwsX8ZnM4jvqcbIDk5Uka07E4=
 
-jdnconvertiblecalendar@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/jdnconvertiblecalendar/-/jdnconvertiblecalendar-0.0.2.tgz#4bfd8b220f9fd8bb105308e9f3181f7d927f3503"
-  integrity sha512-I7z4EGAFtBcEJyOmxJk+MM8Te3lq5OsNN20eW06jNANcQWJpQ855eqG2oPFgIzT2Xoel2KURfgYpuE7ACB5zPA==
+jdnconvertiblecalendar@0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/jdnconvertiblecalendar/-/jdnconvertiblecalendar-0.0.3.tgz#a4e6106340b27bc06bf08cd00912960c666693cc"
+  integrity sha512-AxqmzIkHLE/iEZuej5S9zTqXOAvtHJIk6iMPM3tLBha9UBclxXqXGeqJtclMflVHuvpzm06e0zJ2YVCSA8vtQg==
 
 js-base64@^2.1.8:
   version "2.5.1"


### PR DESCRIPTION
Uses `JDNConvertibleCalendar` 0.0.3 which now supports the creation of calendar dates from calendar periods (https://dhlab-basel.github.io/JDNConvertibleCalendar/docs/classes/_jdnconvertiblecalendar_.jdnconvertiblecalendarmodule.jdnconvertiblecalendar.html#constructor). Previously, calendar dates had to be created from JDN periods.