### PR TITLE
chore(release): prepare version 0.0.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8176,9 +8176,9 @@
       "dev": true
     },
     "jdnconvertiblecalendar": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/jdnconvertiblecalendar/-/jdnconvertiblecalendar-0.0.5.tgz",
-      "integrity": "sha512-/yBqMepJNHxy+yS4Llt0KQPsHGkMi1FVwcE77cpiJZh2RwoNyGBXOwFz4Am5FNZYBF3oiL39FMzHRwwf6yl6xg=="
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/jdnconvertiblecalendar/-/jdnconvertiblecalendar-0.0.6.tgz",
+      "integrity": "sha512-3+g+PpPCPPoeyMBj6XywUZR7CHAm9F3sVdHsvUSt1K9pIbxgrE6GH7RETIk2EdPdCXVEUWt/Ia+gVAT9oMOxlw=="
     },
     "jest-worker": {
       "version": "26.3.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@angular/platform-browser-dynamic": "^10.1.0",
     "@angular/router": "^10.1.0",
     "core-js": "^2.5.4",
-    "jdnconvertiblecalendar": "0.0.5",
+    "jdnconvertiblecalendar": "0.0.6",
     "rxjs": "^6.5.5",
     "tslib": "^2.0.0",
     "zone.js": "~0.10.2"

--- a/projects/jdnconvertible-calendar-date-adapter/README.md
+++ b/projects/jdnconvertible-calendar-date-adapter/README.md
@@ -2,21 +2,20 @@
 
 ## Introduction
 
-`JDNConvertibleCalendarDateAdapter` provides an implementation of the Angular Material `DateAdapter` 
-(<https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings>) for `JDNConvertibleCalendar` (<https://www.npmjs.com/package/jdnconvertiblecalendar>), 
-so that the Angular Material DatePicker UI can be used with different calendar formats.
+`JDNConvertibleCalendarDateAdapter` provides an implementation of the Angular Material [DateAdapter](https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings>) for [JDNConvertibleCalendar](https://www.npmjs.com/package/jdnconvertiblecalendar), 
+so that the Angular Material DatePicker UI can be used with different calendars.
 
 ## NPM Package
 
-`JDNConvertibleCalendarDateAdapter` is available as an npm module: <https://www.npmjs.com/package/jdnconvertiblecalendardateadapter>.
+`JDNConvertibleCalendarDateAdapter` is available as an [npm module](https://www.npmjs.com/package/jdnconvertiblecalendardateadapter).
 
 ## Use with Angular Material Datepicker
 
 Add `jdnconvertiblecalendardateadapter` and `jdnconvertiblecalendar` to the dependencies in your `package.json` and run `npm install`. 
-Add `MatJDNConvertibleCalendarDateAdapterModule` to your application's module configuration. See <https://github.com/dhlab-basel/JDNConvertibleCalendarDateAdapter/blob/develop/src/app/app.module.ts> as an example. 
+Add `MatJDNConvertibleCalendarDateAdapterModule` to your application's module configuration. See [app.module.ts](../../src/app/app.module.ts) as an example. 
 
-See also <https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings> for instructions how to integrate it with Angular Material.
+See also [Angular Material docs](https://material.angular.io/components/datepicker/overview#choosing-a-date-implementation-and-date-format-settings) for instructions how to integrate it with Angular Material.
 
 ## Angular Version
 
-This module works with Angular 10 and Angular Material 10 (see `projects/jdnconvertible-calendar-date-adapter/package.json`). 
+This module works with Angular 10 and Angular Material 10 (see [package.json](package.json)). 

--- a/projects/jdnconvertible-calendar-date-adapter/package.json
+++ b/projects/jdnconvertible-calendar-date-adapter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jdnconvertiblecalendardateadapter",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Implementation of Angular Material DateAdapter for JDNConvertibleCalendar",
   "keywords": [
     "Angular Material Datepicker",
@@ -27,6 +27,6 @@
     "@angular/animations": "^10.1.0",
     "@angular/cdk": "^10.2.0",
     "@angular/material": "^10.2.0",
-    "jdnconvertiblecalendar": "0.0.5"
+    "jdnconvertiblecalendar": "0.0.6"
   }
 }


### PR DESCRIPTION
prepare version 0.0.15

this version uses jdnconvertiblecalendar 0.0.6 (new build options) so Angular can optimize the build